### PR TITLE
reference: Add category properties

### DIFF
--- a/examples/reference/arc/.property.yml
+++ b/examples/reference/arc/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/box/.property.yml
+++ b/examples/reference/box/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/ellipse/.property.yml
+++ b/examples/reference/ellipse/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/line/.property.yml
+++ b/examples/reference/line/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/point/.property.yml
+++ b/examples/reference/point/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/quad/.property.yml
+++ b/examples/reference/quad/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives

--- a/examples/reference/rect/.property.yml
+++ b/examples/reference/rect/.property.yml
@@ -1,0 +1,2 @@
+category: Shape
+subcategory: 2D Primitives


### PR DESCRIPTION
To set category and subcategory for reference docs, the information about it is needed in example/reference folders.

Signed-off-by: Ce Gao <ce.gao@outlook.com>