### PR TITLE
ci: Remove renjin specific config

### DIFF
--- a/.ci/init.cmd
+++ b/.ci/init.cmd
@@ -22,4 +22,3 @@ perl -i.bak -pe "s|\@\@executable\@\@|%executable%|g" build.xml && del build.xml
 perl -i.bak -pe "s|\@\@processing\@\@|%processing%|g" build.xml && del build.xml.bak
 perl -i.bak -pe "s|\@\@core\@\@|%core%|g" build.xml && del build.xml.bak
 perl -i.bak -pe "s|\@\@pde\@\@|%pde%|g" build.xml && del build.xml.bak
-perl -i.bak -pe "s|\@\@renjin\@\@|%renjin%|g" build.xml && del build.xml.bak

--- a/scripts/utils/generator-util.sh
+++ b/scripts/utils/generator-util.sh
@@ -30,8 +30,5 @@ function generate-build-config {
   perl -i -pe "s|\@\@executable\@\@|${2}|g" build.xml
   perl -i -pe "s|\@\@core\@\@|${3}|g" build.xml
   perl -i -pe "s|\@\@pde\@\@|${4}|g" build.xml
-
-  # Static path
-  perl -i -pe "s|\@\@renjin\@\@|${renjin}|g" build.xml
   cd - > /dev/null
 }


### PR DESCRIPTION
The config about renjin is deprecated, just remove it from appveyor.

Signed-off-by: Ce Gao <ce.gao@outlook.com>