### PR TITLE
updates for Processing 4

### DIFF
--- a/src/rprocessing/RLangPApplet.java
+++ b/src/rprocessing/RLangPApplet.java
@@ -1,10 +1,12 @@
 package rprocessing;
 
 import java.awt.Component;
+import java.awt.Frame;
 import java.awt.Window;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +41,7 @@ import rprocessing.util.RScriptReader;
 
 /**
  * RlangPApplet PApplet for R language, powered by Renjin.
- * 
+ *
  * @author github.com/gaocegege
  */
 public class RLangPApplet extends BuiltinApplet {
@@ -62,6 +64,8 @@ public class RLangPApplet extends BuiltinApplet {
 
   private final CountDownLatch finishedLatch = new CountDownLatch(1);
 
+  private Field frameField;
+
   private RSketchError terminalException = null;
 
   private boolean hasSize = false;
@@ -69,7 +73,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Mode for Processing.
-   * 
+   *
    * @author github.com/gaocegege
    */
   private enum Mode {
@@ -107,7 +111,7 @@ public class RLangPApplet extends BuiltinApplet {
     if (isSameClass(source, ExpressionVector.class)) {
       ExpressionVector ev = (ExpressionVector) source;
       // Stores the expressions except size().
-      List<SEXP> sexps = new ArrayList<SEXP>();
+      List<SEXP> sexps = new ArrayList<>();
       for (int i = ev.length() - 1; i >= 0; --i) {
         if (isSameClass(ev.get(i), FunctionCall.class)
             && isSameClass(((FunctionCall) ev.get(i)).getFunction(), Symbol.class)) {
@@ -173,13 +177,22 @@ public class RLangPApplet extends BuiltinApplet {
       }
     } finally {
       Thread.setDefaultUncaughtExceptionHandler(null);
-      if (PApplet.platform == PConstants.MACOSX
+      if (PApplet.platform == PConstants.MACOS
           && Arrays.asList(arguments).contains("fullScreen")) {
         // Frame should be OS-X fullscreen, and it won't stop being that unless the jvm
         // exits or we explicitly tell it to minimize.
         // (If it's disposed, it'll leave a gray blank window behind it.)
         log("Disabling fullscreen.");
-        macosxFullScreenToggle(frame);
+        if (frameField != null) {
+          try {
+            Frame frame = (Frame) frameField.get(this);
+            // This is probably a holdover from Processing 2.x
+            // and likely shouldn't be used anymore. [fry 210703]
+            macosxFullScreenToggle(frame);
+          } catch (Exception e) {
+            // safe enough to ignore; this was a workaround
+          }
+        }
       }
       if (surface instanceof PSurfaceFX) {
         // Sadly, JavaFX is an abomination, and there's no way to run an FX sketch more than once,
@@ -215,14 +228,32 @@ public class RLangPApplet extends BuiltinApplet {
     }
   }
 
+  // method to find the frame field, rather than relying on an Exception
+  private Field getFrameField() {
+    for (Field field : getClass().getFields()) {
+      if (field.getName().equals("frame")) {
+        return field;
+      }
+    }
+    return null;
+  }
+
   /**
-   * 
+   *
    * @see processing.core.PApplet#initSurface()
    */
   @Override
   protected PSurface initSurface() {
     final PSurface s = super.initSurface();
-    this.frame = null; // eliminate a memory leak from 2.x compat hack
+    frameField = getFrameField();
+    if (frameField != null) {
+      try {
+        // eliminate a memory leak from 2.x compat hack
+        frameField.set(this, null);
+      } catch (Exception e) {
+        // safe enough to ignore; this was a workaround
+      }
+    }
     // s.setTitle(pySketchPath.getFileName().toString().replaceAll("\\..*$", ""));
     if (s instanceof PSurfaceAWT) {
       final PSurfaceAWT surf = (PSurfaceAWT) s;
@@ -293,7 +324,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Evaluate the program code.
-   * 
+   *
    * @see processing.core.PApplet#setup()
    */
   @Override
@@ -334,7 +365,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Call the draw function in R script.
-   * 
+   *
    * @see processing.core.PApplet#draw()
    */
   @Override
@@ -348,7 +379,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Detect whether the program is in active mode.
-   * 
+   *
    * @return
    */
   @SuppressWarnings("rawtypes")
@@ -361,7 +392,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Detect whether the program is in mix mode. After: isActiveMode()
-   * 
+   *
    * @return
    */
   private boolean isMixMode() {
@@ -495,7 +526,7 @@ public class RLangPApplet extends BuiltinApplet {
 
   /**
    * Return whether the object has same class with clazz.
-   * 
+   *
    * @param obj
    * @param clazz
    * @return

--- a/src/rprocessing/RLangPApplet.java
+++ b/src/rprocessing/RLangPApplet.java
@@ -177,7 +177,7 @@ public class RLangPApplet extends BuiltinApplet {
       }
     } finally {
       Thread.setDefaultUncaughtExceptionHandler(null);
-      if (PApplet.platform == PConstants.MACOS
+      if (PApplet.platform == PConstants.MACOSX
           && Arrays.asList(arguments).contains("fullScreen")) {
         // Frame should be OS-X fullscreen, and it won't stop being that unless the jvm
         // exits or we explicitly tell it to minimize.

--- a/src/rprocessing/Runner.java
+++ b/src/rprocessing/Runner.java
@@ -34,7 +34,7 @@ public class Runner {
   static {
     log("Getting the architecture.");
     final int archBits = Integer.parseInt(System.getProperty("sun.arch.data.model"));
-    if (PApplet.platform == PConstants.MACOS) {
+    if (PApplet.platform == PConstants.MACOSX) {
       ARCH = "macosx" + archBits;
     } else if (PApplet.platform == PConstants.WINDOWS) {
       ARCH = "macosx" + archBits;

--- a/src/rprocessing/Runner.java
+++ b/src/rprocessing/Runner.java
@@ -20,7 +20,7 @@ import rprocessing.util.StreamPrinter;
 
 /**
  * R script runner
- * 
+ *
  * @author github.com/gaocegege
  */
 public class Runner {
@@ -34,7 +34,7 @@ public class Runner {
   static {
     log("Getting the architecture.");
     final int archBits = Integer.parseInt(System.getProperty("sun.arch.data.model"));
-    if (PApplet.platform == PConstants.MACOSX) {
+    if (PApplet.platform == PConstants.MACOS) {
       ARCH = "macosx" + archBits;
     } else if (PApplet.platform == PConstants.WINDOWS) {
       ARCH = "macosx" + archBits;

--- a/src/rprocessing/mode/run/SketchRunner.java
+++ b/src/rprocessing/mode/run/SketchRunner.java
@@ -15,7 +15,7 @@ import rprocessing.mode.run.RMIUtils.RMIProblem;
 import rprocessing.util.Printer;
 
 /**
- * 
+ *
  * @author github.com/gaocegege
  */
 public class SketchRunner implements SketchService {
@@ -36,7 +36,7 @@ public class SketchRunner implements SketchService {
   public SketchRunner(final String id, final ModeService modeService) {
     this.id = id;
     this.modeService = modeService;
-    if (PApplet.platform == PConstants.MACOSX) {
+    if (PApplet.platform == PConstants.MACOS) {
       try {
         OSXAdapter.setQuitHandler(this, this.getClass().getMethod("preventUserQuit"));
       } catch (final Throwable e) {
@@ -61,7 +61,7 @@ public class SketchRunner implements SketchService {
    * <p>
    * But if we've received a shutdown request from the {@link SketchServiceProcess} on the PDE VM,
    * then we permit the quit to proceed.
-   * 
+   *
    * @return true iff the SketchRunner should quit.
    */
   public boolean preventUserQuit() {

--- a/src/rprocessing/mode/run/SketchRunner.java
+++ b/src/rprocessing/mode/run/SketchRunner.java
@@ -36,7 +36,7 @@ public class SketchRunner implements SketchService {
   public SketchRunner(final String id, final ModeService modeService) {
     this.id = id;
     this.modeService = modeService;
-    if (PApplet.platform == PConstants.MACOS) {
+    if (PApplet.platform == PConstants.MACOSX) {
       try {
         OSXAdapter.setQuitHandler(this, this.getClass().getMethod("preventUserQuit"));
       } catch (final Throwable e) {

--- a/src/test/e2e/util/ImageUtils.java
+++ b/src/test/e2e/util/ImageUtils.java
@@ -10,11 +10,11 @@ import processing.core.PApplet;
 import processing.core.PImage;
 
 /**
- * 
+ *
  * @author github.com/gaocegege
  */
 public class ImageUtils {
-  
+
   public static float diffImage(File actualFile, URL testURL) throws IOException {
     PImage actualImage = new PImage(ImageIO.read(actualFile));
     PImage testImage = new PImage(ImageIO.read(testURL));
@@ -29,12 +29,12 @@ public class ImageUtils {
     i1.loadPixels();
     int[] ip1 = i1.pixels;
     for (int n = 0; n < ip0.length; n++) {
-      int pxl0 = ip0[n]
+      int pxl0 = ip0[n];
       int r0, g0, b0;
       r0 = (pxl0 >> 20) & 0xF;
       g0 = (pxl0 >> 12) & 0xF;
       b0 = (pxl0 >> 4) & 0xF;
-      int pxl1 = ip1[n]
+      int pxl1 = ip1[n];
       int r1, g1, b1;
       r1 = (pxl1 >> 20) & 0xF;
       g1 = (pxl1 >> 12) & 0xF;


### PR DESCRIPTION
Changes included: 

* Changes to use reflection to access the deprecated/removed `frame` field
* Some whitespace was trimmed automatically by my editor; feel free to ignore
* Should work fine with both Processing 4.x and 3.x